### PR TITLE
Redmine 3.3.x compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem "active_cmis", "~>0.3.5"

--- a/app/models/cmis_attachment.rb
+++ b/app/models/cmis_attachment.rb
@@ -34,7 +34,7 @@ class CmisAttachment < ActiveRecord::Base
   acts_as_activity_provider :type => 'documents',
                             :permission => :view_cmis_documents,
                             :author_key => :author_id,
-                            :find_options => {:select => "#{CmisAttachment.table_name}.*", 
+                            :scope => {:select => "#{CmisAttachment.table_name}.*", 
                                               :joins => "LEFT JOIN #{CmisDocument.table_name} ON #{CmisDocument.table_name}.id = #{CmisAttachment.table_name}.cmis_document_id " +
                                                         "LEFT JOIN #{Project.table_name} ON #{CmisDocument.table_name}.project_id = #{Project.table_name}.id"}
 
@@ -251,7 +251,7 @@ class CmisAttachment < ActiveRecord::Base
   end
   
   def self.get_nombre_si_repetido(nombre_archivo, path_archivo, document)
-  	repetido = CmisAttachment.find(:first, :conditions =>["cmis_document_id= ? and path= ?", document.id.to_s  ,  path_archivo + nombre_archivo])
+  	repetido = CmisAttachment.where("cmis_document_id= ? and path= ?", document.id.to_s, path_archivo + nombre_archivo).first
   	if repetido # si hay un documento ya con ese nombre, le meto el timestamp
   		nombre_archivo = Time.now.to_i.to_s + "_" + nombre_archivo
   	end

--- a/app/models/cmis_document.rb
+++ b/app/models/cmis_document.rb
@@ -32,7 +32,7 @@ class CmisDocument < ActiveRecord::Base
   belongs_to :category, :class_name => "DocumentCategory", :foreign_key => "category_id"
   belongs_to :project
 
-  acts_as_searchable :columns => ['title', "#{table_name}.title"], :include => :project
+  acts_as_searchable :columns => ['title', "#{table_name}.title"], :scope => preload(:project)
 
 # category is now optional
 #  validates_presence_of :project, :title, :category
@@ -121,7 +121,7 @@ class CmisDocument < ActiveRecord::Base
   end
   
   def attachments
-    return CmisAttachment.find(:all, :conditions => ["cmis_document_id=" + self.id.to_s] , :order => "created_on DESC")
+    return CmisAttachment.where(cmis_document_id: self.id.to_s).order("created_on DESC").all
   end
   
   def self.category_path(project, category)
@@ -142,7 +142,7 @@ class CmisDocument < ActiveRecord::Base
   end
   
   def self.check_repeated(document)
-    repeated = CmisDocument.find(:first, :conditions =>["path= ?", document.path])
+    repeated = CmisDocument.where(path: document.path).first
     if repeated
       return true
     else

--- a/app/models/cmis_project_setting.rb
+++ b/app/models/cmis_project_setting.rb
@@ -4,7 +4,7 @@ class CmisProjectSetting < ActiveRecord::Base
   belongs_to :project
   
   def self.find_or_create(pj_id)
-    setting = CmisProjectSetting.find(:first, :conditions => ['project_id = ?', pj_id])
+    setting = CmisProjectSetting.find_by project_id: pj_id
         unless setting
           setting = CmisProjectSetting.new
           setting.project_id = pj_id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,7 @@
 # Looking forward your comments and suggestions! info@zuinqstudio.com
 
 en:
+  label_use_category: "User Category"
   permission_view_cmis_documents: "View Documents"
   permission_manage_cmis_documents: "Manage Documents"
   label_usuario_cmis: "Cmis User"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -16,6 +16,7 @@
 # FR Translation by Bruno Spyckerelle
 
 fr:
+  label_use_category: "Catégorie utilisateur"
   permission_view_cmis_documents: "Voir les documents"
   permission_manage_cmis_documents: "Gérer les documents"
   label_usuario_cmis: "Cmis Utilisateur"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,8 +14,8 @@
 # Looking forward your comments and suggestions! info@zuinqstudio.com
 
 RedmineApp::Application.routes.draw do
-  match 'sync_cmis_spaces', :to => 'cmis', :via => [:get, :post]
-  match 'projects/:project_id/cmis/:action', :to => 'cmis', :via => [:get, :post]
-  match 'projects/:project_id/:id/cmis/:action', :to => 'cmis', :via => [:get, :post]
+  match 'sync_cmis_spaces', :controller => 'cmis', :via => [:get, :post]
+  match 'projects/:project_id/cmis/:action', :controller => 'cmis', :via => [:get, :post]
+  match 'projects/:project_id/:id/cmis/:action', :controller => 'cmis', :via => [:get, :post]
   match 'projects/:id/cmis_project_setting/:action', :controller => 'cmis_project_setting', :via => [:get, :post, :put]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,5 @@ RedmineApp::Application.routes.draw do
   match 'sync_cmis_spaces', :controller => 'cmis', :via => [:get, :post]
   match 'projects/:project_id/cmis/:action', :controller => 'cmis', :via => [:get, :post]
   match 'projects/:project_id/:id/cmis/:action', :controller => 'cmis', :via => [:get, :post]
-  match 'projects/:id/cmis_project_setting/:action', :controller => 'cmis_project_setting', :via => [:get, :post, :put]
+  match 'projects/:id/cmis_project_setting/:action', :controller => 'cmis_project_setting', :via => [:get, :post, :put, :patch]
 end

--- a/init.rb
+++ b/init.rb
@@ -35,8 +35,8 @@ Redmine::Plugin.register :redmine_cmis do
 	menu :project_menu, :cmis, { :controller => 'cmis', :action => 'index' }, :caption => :cmis, :after => :documents, :param => :project_id
 
 	settings :default => {
-    'server_url' => 'http://localhost:8080/alfresco/service/cmis',
-    'repository_id' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+    'server_url' => 'http://alfresco.example.com:8080/alfresco/api/-default-/public/cmis/versions/1.0/atom',
+    'repository_id' => '-default-',
 		'server_login' => 'user',
 		'server_password' => 'password',
 		'documents_path_base' => 'REDMINE',

--- a/init.rb
+++ b/init.rb
@@ -28,7 +28,7 @@ Redmine::Plugin.register :redmine_cmis do
 	name 'Redmine 2.x Cmis Plugin'
 	author 'Zuinq Studio'
 	description 'Store project files on your Cmis server'
-	version '0.0.2'
+	version '0.0.3'
 	url 'http://www.zuinqstudio.com/en/funny-experiments-downloads'
 	author_url 'http://www.zuinqstudio.com'
 

--- a/init.rb
+++ b/init.rb
@@ -25,7 +25,7 @@ Rails.configuration.to_prepare do
 end
 
 Redmine::Plugin.register :redmine_cmis do
-	name 'Redmine 2.x Cmis Plugin'
+	name 'Redmine 3.x Cmis Plugin'
 	author 'Zuinq Studio'
 	description 'Store project files on your Cmis server'
 	version '0.0.3'

--- a/lib/cmis_module.rb
+++ b/lib/cmis_module.rb
@@ -81,7 +81,7 @@ module CmisModule
   
   def copy_document_relative(fromPath, toPath, project_id, isRelativePath)
     # Read document content
-    content = read_document_relative(fromPath, isRelativePath)
+    content = read_document_relative(fromPath, project_id, isRelativePath)
     
     # Save document into destination folder
     save_document_relative(get_path_to_folder(toPath), get_document_name(toPath), content, project_id, isRelativePath)    
@@ -96,7 +96,7 @@ module CmisModule
     copy_document_relative(fromPath, toPath, project_id, isRelativePath)
     
     # Remove old document
-    remove_document_relative(fromPath, isRelativePath)    
+    remove_document_relative(fromPath, project_id, isRelativePath)    
   end
   
   def read_document(path, project_id)
@@ -199,7 +199,7 @@ module CmisModule
       save_folder_relative(toPath, project_id, isRelativePath)
       
       # Get source folder
-      sourceFolder = get_folder_relative(fromPath, isRelativePath)
+      sourceFolder = get_folder_relative(fromPath, project_id, isRelativePath)
       
       # Copy subfolders in folder
       if sourceFolder != nil
@@ -209,7 +209,7 @@ module CmisModule
       
         # Remove documents in folder
         sourceFolder.items.select {|o| o.is_a?(ActiveCMIS::Document)}.map {|o|
-          copy_document_relative(compose_path(fromPath, o.name), compose_path(toPath, o.name), isRelativePath)
+          copy_document_relative(compose_path(fromPath, o.name), compose_path(toPath, o.name), project_id, isRelativePath)
         }
       end
     end
@@ -225,7 +225,7 @@ module CmisModule
       copy_folder_relative(fromPath, toPath, isRelativePath)
     
       # Remove old document
-      remove_folder_relative(fromPath, isRelativePath)
+      remove_folder_relative(fromPath, project_id, isRelativePath)
     end    
   end
   


### PR DESCRIPTION
Heavily tested with redmine 3.3.2 and Alfresco Community 5.2 (201705) with HAProxy SSL offloading.

Alfresco 5.x CMIS url:
http://alfresco.example.com:8080/alfresco/api/-default-/public/cmis/versions/1.0/atom
